### PR TITLE
Unify visualization styling and add map tooltip

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -9,4 +9,67 @@
 /* Also change hover state if needed */
 #scrollUp:hover:before {
     background: #000000 !important;
+}/* Unified legend styles */
+.legend {
+    background: white;
+    padding: 10px;
+    border-radius: 5px;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    color: #333;
+    font-size: 12px;
+    max-width: 180px;
+    font-family: 'Open Sans', sans-serif;
+}
+
+.legend-title,
+.legend h3,
+.legend-group-title {
+    font-family: 'Open Sans', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    margin: 0 0 8px 0;
+    color: #111;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 4px;
+}
+
+.legend-item,
+.legend-cuisine-item,
+.category-item {
+    font-family: 'Open Sans', sans-serif;
+    font-size: 12px;
+    color: #333;
+}
+
+/* Tooltip styles */
+.tooltip,
+#tooltip,
+#tooltip-map,
+#tooltip-bubble,
+#globe-tooltip,
+#radial-tooltip {
+    position: fixed;
+    background: rgba(40,40,40,0.9);
+    color: #fff;
+    padding: 10px 12px;
+    border-radius: 6px;
+    font-family: 'Open Sans', sans-serif;
+    font-size: 13px;
+    pointer-events: none;
+    opacity: 0;
+    transform: scale(0.95);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 10000;
+    display: none;
+}
+
+.tooltip.active,
+#tooltip.active,
+#tooltip-map.active,
+#tooltip-bubble.active,
+#globe-tooltip.active,
+#radial-tooltip.active {
+    display: block;
+    opacity: 1;
+    transform: scale(1);
 }

--- a/index.html
+++ b/index.html
@@ -1274,14 +1274,11 @@
                            
 
                             </div>
-                            <div id="tooltip-map"></div>
+                            <div id="tooltip-map" class="tooltip"></div>
 
                             <!-- Cuisine Types legend positioned to show full text -->
-                            <div class="legend"
-                                style="position:absolute; top:20px; right:-140px; background:white; padding:10px; border-radius:5px; color:#333; font-size:12px; z-index:10; max-width:180px; box-shadow: 0 2px 10px rgba(0,0,0,0.1);">
-                                <h3
-                                    style="font-size:14px; margin:0 0 8px 0; color:#111; border-bottom:1px solid #eee; padding-bottom:4px; font-weight:bold;">
-                                    Cuisine Types</h3>
+                            <div class="legend" style="position:absolute; top:20px; right:-140px;">
+                                <h3 class="legend-title">Cuisine Types</h3>
                                 <div id="legend-groups" style="display: flex; flex-direction: column; gap: 5px;">
                                     <!-- Content filled dynamically by JavaScript -->
                                 </div>
@@ -2998,12 +2995,8 @@
                     <div id="bubble-container-chart"
                         style="position: relative; width: 100%; height: 650px; background-color: white;">
                         <!-- Visualization Guide legend positioned to avoid overlap -->
-                        <div class="legend"
-                            style="position:absolute; top:20px; right:70px; background:white; padding:12px 14px; border-radius:8px; color:#333; font-size:13px; z-index:10; max-width:230px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); font-family:'Open Sans', sans-serif;">
-                            <h3
-                                style="font-size:15px; margin:0 0 10px 0; color:#111; border-bottom:1px solid #eee; padding-bottom:6px;">
-                                Visualization Guide
-                            </h3>
+                        <div class="legend" style="position:absolute; top:20px; right:70px; max-width:230px;">
+                            <h3 class="legend-title">Visualization Guide</h3>
                             <div style="margin-bottom:10px;">
                                 <div style="font-weight:600; font-size:12px; color:#444; margin-bottom:6px;">Bubble
                                     Types</div>
@@ -3815,16 +3808,12 @@
                                 style="flex: 1; position: relative; display: flex; justify-content: center; align-items: center; max-width: 70%;">
                                 <svg id="radial-chart" viewBox="-375 -375 750 750"
                                     style="width: 100%; height: 100%; display: block; margin: 0 auto; overflow: visible;"></svg>
-                                <div id="radial-tooltip"
-                                    style="position: absolute; text-align: center; padding: 8px 12px; background: white; border: 1px solid #ccc; border-radius: 4px; pointer-events: none; font-size: 13px; box-shadow: 2px 2px 5px rgba(0,0,0,0.1); opacity: 0;">
-                                </div>
+                                <div id="radial-tooltip" class="tooltip" style="position: absolute;"></div>
                             </div>
   <!-- Replaced Ingredient Categories -->
-  <div id="category-labels"
-  style="position: absolute; top: 20px; right: 20px; background: white; padding: 14px; border-radius: 8px; color: rgb(51, 51, 51); font-size: 10px; z-index: 10; box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 10px; font-family: 'Open Sans', sans-serif; max-width: 240px; overflow: visible;">
-  <h3
-      style="margin-top: 0px; font-size: 13px; font-weight: 600; color: rgb(17, 17, 17); border-bottom: 1px solid rgb(238, 238, 238); padding-bottom: 6px; margin-bottom: 12px; text-align: center; font-family: 'Open Sans', sans-serif;">
-      Ingredient Categories</h3>
+  <div id="category-labels" class="legend"
+  style="position: absolute; top: 20px; right: 20px; max-width: 240px;">
+  <h3 class="legend-title" style="text-align: center;">Ingredient Categories</h3>
   <div style="display: flex; flex-direction: column; gap: 4px;">
       <div class="category-item"
           style="display: flex; align-items: center; gap: 4px; font-size: 10px; color: rgb(51, 51, 51); background: rgb(245, 245, 245); padding: 3px 8px; border-radius: 16px; margin: 2px; border-left: 3px solid rgb(176, 190, 197); cursor: pointer;"


### PR DESCRIPTION
## Summary
- standardize legend and tooltip typography via `custom.css`
- apply unified legend classes to restaurant map, bubble chart, and radial chart
- enable tooltip styling on restaurant map

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68431af29ed08330add5083c7e2b6a84