### PR TITLE
Unify tooltip styles across visualizations

### DIFF
--- a/css/outro.css
+++ b/css/outro.css
@@ -73,10 +73,28 @@
         #tooltip,
         #tooltip-map,
         #tooltip-bubble,
+        #radial-tooltip,
+        #chord-tooltip,
         #globe-tooltip,
-        #globe-tooltip-fixed {
+        #globe-tooltip-fixed,
+        .viz-tooltip {
             font-family: 'Open Sans', sans-serif;
             font-size: 13px;
+        }
+
+        /* Estilo unificado para todos os tooltips */
+        .tooltip-common {
+            background: rgba(255, 255, 255, 0.98);
+            color: #333;
+            padding: 10px 15px;
+            border-radius: 6px;
+            font-size: 13px;
+            font-family: 'Open Sans', sans-serif;
+            pointer-events: none;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+            max-width: 280px;
+            line-height: 1.5em;
+            border: none;
         }
 
         /* Padronização de controles e botões */

--- a/index.html
+++ b/index.html
@@ -1274,7 +1274,7 @@
                            
 
                             </div>
-                            <div id="tooltip-map"></div>
+                            <div id="tooltip-map" class="tooltip tooltip-common"></div>
 
                             <!-- Cuisine Types legend positioned to show full text -->
                             <div class="legend"
@@ -2270,8 +2270,8 @@
                             <div id="legendContent" style="display: flex; flex-direction: column; gap: 5px;"></div>
                         </div>
 
-                        <div id="globe-tooltip"
-                            style="display:none; position:absolute; background:white; padding:8px 12px; border-radius:4px; color:#333; pointer-events:none; font-size:13px; z-index:1000; box-shadow: 0 2px 10px rgba(0,0,0,0.2);">
+                        <div id="globe-tooltip" class="tooltip-common"
+                            style="display:none; position:absolute;">
                         </div>
                     </div>
                 </div>
@@ -3084,8 +3084,8 @@
                     </div>
 
                     <!-- Add the tooltip inside the existing bubble-viz -->
-                    <div id="tooltip-bubble"
-                        style="position:absolute; background:rgba(255,255,255,0.98); color:#333; padding:12px 15px; border-radius:6px; font-size:14px; font-family:'Open Sans',sans-serif; pointer-events:none; box-shadow:0 4px 15px rgba(0,0,0,0.15); max-width:280px; line-height:1.5em; opacity:0; border:none; z-index:9999; transition:opacity 0.2s ease-in-out;">
+                    <div id="tooltip-bubble" class="tooltip-common"
+                        style="position:absolute; opacity:0;">
                     </div> <!-- Tooltip container for bubble chart -->
                 </div>
 
@@ -3815,8 +3815,8 @@
                                 style="flex: 1; position: relative; display: flex; justify-content: center; align-items: center; max-width: 70%;">
                                 <svg id="radial-chart" viewBox="-375 -375 750 750"
                                     style="width: 100%; height: 100%; display: block; margin: 0 auto; overflow: visible;"></svg>
-                                <div id="radial-tooltip"
-                                    style="position: absolute; text-align: center; padding: 8px 12px; background: white; border: 1px solid #ccc; border-radius: 4px; pointer-events: none; font-size: 13px; box-shadow: 2px 2px 5px rgba(0,0,0,0.1); opacity: 0;">
+                                <div id="radial-tooltip" class="tooltip-common"
+                                    style="position: absolute; pointer-events: none; opacity: 0;">
                                 </div>
                             </div>
   <!-- Replaced Ingredient Categories -->
@@ -4195,21 +4195,9 @@ g.selectAll("line")
   </section>
   
   <!-- Tooltip colocado fora, com posição fixa -->
-  <div id="chord-tooltip"
-       style="
-         position: fixed;
-         text-align: center;
-         padding: 8px 12px;
-         background: rgba(0,0,0,0.9);
-         color: white;
-         border-radius: 4px;
-         pointer-events: none;
-         font-size: 13px;
-         opacity: 0;
-         z-index: 1000;
-         box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-       ">
-  </div>
+    <div id="chord-tooltip" class="tooltip-common"
+         style="position: fixed; pointer-events: none; opacity: 0; display: none;">
+    </div>
   
   <script>
   document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Summary
- standardize tooltip font settings in `outro.css`
- add a reusable `.tooltip-common` class for uniform appearance
- apply `.tooltip-common` to map, radial, bubble, globe and chord tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431d94b9a88330ae0d4c5ef9e79eea